### PR TITLE
예제코드를 정돈하라

### DIFF
--- a/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/DocumentStateMachineRestController.kt
+++ b/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/DocumentStateMachineRestController.kt
@@ -7,7 +7,6 @@ import org.springframework.statemachine.StateMachine
 import org.springframework.statemachine.StateMachineContext
 import org.springframework.statemachine.StateMachinePersist
 import org.springframework.statemachine.service.StateMachineService
-import org.springframework.util.ObjectUtils
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -81,7 +80,7 @@ class DocumentStateMachineRestController(
 
     // currentStateMachine 이 null은 아니지만, currentStateMachine의 id가 주어진 machineId와 다를 경우
     // 기존 stateMachine 객체는 release 및 stop 처리를 진행한 후, machineId를 가진 새로운 stateMachine 객체를 생성한다.
-    if (!ObjectUtils.nullSafeEquals(currentStateMachine!!.id, machineId)) {
+    if (currentStateMachine!!.id != machineId) {
       stateMachineService.releaseStateMachine(currentStateMachine!!.id)
       currentStateMachine!!.stopReactively().block()
       currentStateMachine = stateMachineService.acquireStateMachine(machineId)
@@ -100,7 +99,6 @@ class DocumentStateMachineRestController(
         .build()
     )
   }
-
 
   data class StateMachineStatement(
     val machineId: String,

--- a/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/JpaPersisterConfig.kt
+++ b/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/JpaPersisterConfig.kt
@@ -12,7 +12,7 @@ import org.springframework.statemachine.persist.StateMachineRuntimePersister
 class JpaPersisterConfig {
   @Bean
   fun stateMachineRuntimePersister(
-    jpaStateMachineRepository: JpaStateMachineRepository?
+    jpaStateMachineRepository: JpaStateMachineRepository
   ): StateMachineRuntimePersister<DocumentState, DocumentEvent, String> {
     return JpaPersistingStateMachineInterceptor(
       jpaStateMachineRepository

--- a/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/StateMachineServiceConfig.kt
+++ b/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/StateMachineServiceConfig.kt
@@ -13,8 +13,8 @@ import org.springframework.statemachine.service.StateMachineService
 class StateMachineServiceConfig {
   @Bean
   fun stateMachineService(
-    stateMachineFactory: StateMachineFactory<DocumentState, DocumentEvent>?,
-    stateMachineRuntimePersister: StateMachineRuntimePersister<DocumentState, DocumentEvent, String?>?
+    stateMachineFactory: StateMachineFactory<DocumentState, DocumentEvent>,
+    stateMachineRuntimePersister: StateMachineRuntimePersister<DocumentState, DocumentEvent, String>
   ): StateMachineService<DocumentState, DocumentEvent> {
     return DefaultStateMachineService(stateMachineFactory, stateMachineRuntimePersister)
   }

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-java/src/main/java/com/example/statemachine/simple/doument/DocumentStateMachineRestController.java
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-java/src/main/java/com/example/statemachine/simple/doument/DocumentStateMachineRestController.java
@@ -14,7 +14,6 @@ public class DocumentStateMachineRestController {
   private final JdbcTemplate jdbcTemplate;
   private final DocumentStateMachine documentStateMachine;
 
-
   public DocumentStateMachineRestController(
     final JdbcTemplate jdbcTemplate,
     final DocumentStateMachine documentStateMachine) {

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-java/src/main/java/com/example/statemachine/simple/doument/config/DocumentStateMachineConfig.java
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-java/src/main/java/com/example/statemachine/simple/doument/config/DocumentStateMachineConfig.java
@@ -15,7 +15,7 @@ import org.springframework.statemachine.listener.StateMachineListenerAdapter;
 
 @Configuration
 @EnableStateMachine
-public class DocumentStateConfig
+public class DocumentStateMachineConfig
   extends EnumStateMachineConfigurerAdapter<DocumentState, DocumentEvent> {
 
   // 상태 기계 설정을 진행한다.

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/DocumentStateMachineConfig.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/DocumentStateMachineConfig.kt
@@ -15,11 +15,12 @@ import org.springframework.statemachine.listener.StateMachineListenerAdapter
 
 @Configuration
 @EnableStateMachine
-class DocumentStateConfig : EnumStateMachineConfigurerAdapter<DocumentState, DocumentEvent>() {
+class DocumentStateMachineConfig : EnumStateMachineConfigurerAdapter<DocumentState, DocumentEvent>() {
 
   // 상태 기계 설정을 진행한다.
   override fun configure(
-    config: StateMachineConfigurationConfigurer<DocumentState, DocumentEvent>) {
+    config: StateMachineConfigurationConfigurer<DocumentState, DocumentEvent>
+  ) {
 
     config.withConfiguration()
       .autoStartup(true)
@@ -34,12 +35,13 @@ class DocumentStateConfig : EnumStateMachineConfigurerAdapter<DocumentState, Doc
       .state(DocumentState.UNDER_MEDIATION)
       .state(DocumentState.WAITING_FOR_PUBLIC_DISCLOSURE)
       .state(DocumentState.PUBLIC_DISCLOSURE, SendEmailAction()) // state 별 로직을 설정 가능.
-      // .end() // 최종 상태가 존재하는 경우 이 메소드를 통해 설정할 수 있다.
+    // .end() // 최종 상태가 존재하는 경우 이 메소드를 통해 설정할 수 있다.
   }
 
   // 상태 기계의 'event (이벤트)' 와 'state transition (상태 전이)' 를 매핑한다.
   override fun configure(
-    transitions: StateMachineTransitionConfigurer<DocumentState, DocumentEvent>) {
+    transitions: StateMachineTransitionConfigurer<DocumentState, DocumentEvent>
+  ) {
 
     transitions.withExternal()
       .source(DocumentState.DRAFT).target(DocumentState.UNDER_MEDIATION)

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/PersistHandlerConfig.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/PersistHandlerConfig.kt
@@ -11,7 +11,7 @@ import org.springframework.statemachine.StateMachine
 
 @Configuration
 class PersistHandlerConfig(
-  private val stateMachine: StateMachine<DocumentState?, DocumentEvent?>,
+  private val stateMachine: StateMachine<DocumentState, DocumentEvent>,
   private val jdbcTemplate: JdbcTemplate
 ) {
 

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/action/SendEmailAction.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/action/SendEmailAction.kt
@@ -11,7 +11,7 @@ class SendEmailAction : Action<DocumentState, DocumentEvent> {
 
   private val logger: Logger = LoggerFactory.getLogger(SendEmailAction::class.java)
 
-  override fun execute(p0: StateContext<DocumentState, DocumentEvent>?) {
+  override fun execute(p0: StateContext<DocumentState, DocumentEvent>) {
     logger.info("이메일 전송 : [문서가 대외 공개되었습니다.]")
   }
 }

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/lintener/StateMachineListenerAdapterImpl.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/lintener/StateMachineListenerAdapterImpl.kt
@@ -13,8 +13,8 @@ class StateMachineListenerAdapterImpl :
 
   override fun stateChanged(
     from: State<DocumentState, DocumentEvent>?,
-    to: State<DocumentState, DocumentEvent>?
+    to: State<DocumentState, DocumentEvent>
   ) {
-    logger.info("문서의 상태가 {} 에서 {} 로 변경되었습니다.", from?.id, to?.id)
+    logger.info("문서의 상태가 {} 에서 {} 로 변경되었습니다.", from?.id, to.id)
   }
 }

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/persist/DocumentPersistStateMachineHandler.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/persist/DocumentPersistStateMachineHandler.kt
@@ -6,5 +6,5 @@ import org.springframework.statemachine.StateMachine
 import org.springframework.statemachine.recipes.persist.GenericPersistStateMachineHandler
 
 class DocumentPersistStateMachineHandler(
-  stateMachine: StateMachine<DocumentState?, DocumentEvent?>?
-) : GenericPersistStateMachineHandler<DocumentState?, DocumentEvent?>(stateMachine)
+  stateMachine: StateMachine<DocumentState, DocumentEvent>
+) : GenericPersistStateMachineHandler<DocumentState, DocumentEvent>(stateMachine)

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/persist/DocumentStateChangedHistoryWriter.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/persist/DocumentStateChangedHistoryWriter.kt
@@ -10,18 +10,18 @@ import org.springframework.statemachine.state.State
 import org.springframework.statemachine.transition.Transition
 
 class DocumentStateChangedHistoryWriter(private val jdbcTemplate: JdbcTemplate) :
-  AbstractPersistStateMachineHandler.GenericPersistStateChangeListener<DocumentState?, DocumentEvent?> {
+  AbstractPersistStateMachineHandler.GenericPersistStateChangeListener<DocumentState, DocumentEvent> {
 
 
   override fun onPersist(
-    state: State<DocumentState?, DocumentEvent?>?,
-    message: Message<DocumentEvent?>?,
-    transition: Transition<DocumentState?, DocumentEvent?>?,
-    stateMachine: StateMachine<DocumentState?, DocumentEvent?>?
+    state: State<DocumentState, DocumentEvent>,
+    message: Message<DocumentEvent>,
+    transition: Transition<DocumentState, DocumentEvent>,
+    stateMachine: StateMachine<DocumentState, DocumentEvent>
   ) {
-    if (message!!.headers.containsKey("document")) {
+    if (message.headers.containsKey("document")) {
       val documentId = message.headers.get("document", Integer::class.java)
-      val event = transition!!.trigger.event!!
+      val event = transition.trigger.event!!
       val prevState = transition.source.id!!
       val changedState = transition.target.id!!
 

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/persist/DocumentStateUpdater.kt
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/persist/DocumentStateUpdater.kt
@@ -10,21 +10,21 @@ import org.springframework.statemachine.state.State
 import org.springframework.statemachine.transition.Transition
 
 class DocumentStateUpdater(private val jdbcTemplate: JdbcTemplate) :
-  AbstractPersistStateMachineHandler.GenericPersistStateChangeListener<DocumentState?, DocumentEvent?> {
+  AbstractPersistStateMachineHandler.GenericPersistStateChangeListener<DocumentState, DocumentEvent> {
 
 
   override fun onPersist(
-    state: State<DocumentState?, DocumentEvent?>?,
-    message: Message<DocumentEvent?>?,
-    transition: Transition<DocumentState?, DocumentEvent?>?,
-    stateMachine: StateMachine<DocumentState?, DocumentEvent?>?
+    state: State<DocumentState, DocumentEvent>,
+    message: Message<DocumentEvent>,
+    transition: Transition<DocumentState, DocumentEvent>,
+    stateMachine: StateMachine<DocumentState, DocumentEvent>
   ) {
-    if (message!!.headers.containsKey("document")) {
+    if (message.headers.containsKey("document")) {
       val documentId = message.headers.get("document", Integer::class.java)
 
       jdbcTemplate.update(
-        "update documents set state = ? where id = ?",
-        state!!.id.toString(), documentId
+        "UPDATE documents SET state = ? WHERE id = ?",
+        state.id.toString(), documentId
       )
     }
   }

--- a/simple-statemachine/simple-statemachine-java/src/main/java/com/example/statemachine/simple/doument/config/DocumentStateMachineConfig.java
+++ b/simple-statemachine/simple-statemachine-java/src/main/java/com/example/statemachine/simple/doument/config/DocumentStateMachineConfig.java
@@ -15,7 +15,7 @@ import org.springframework.statemachine.listener.StateMachineListenerAdapter;
 
 @Configuration
 @EnableStateMachine
-public class DocumentStateConfig
+public class DocumentStateMachineConfig
   extends EnumStateMachineConfigurerAdapter<DocumentState, DocumentEvent> {
 
   // 상태 기계 설정을 진행한다.

--- a/simple-statemachine/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/DocumentStateMachineConfig.kt
+++ b/simple-statemachine/simple-statemachine-kotlin/src/main/kotlin/com/example/statemachine/simple/document/config/DocumentStateMachineConfig.kt
@@ -15,12 +15,11 @@ import org.springframework.statemachine.listener.StateMachineListenerAdapter
 
 @Configuration
 @EnableStateMachine
-class DocumentStateConfig : EnumStateMachineConfigurerAdapter<DocumentState, DocumentEvent>() {
+class DocumentStateMachineConfig : EnumStateMachineConfigurerAdapter<DocumentState, DocumentEvent>() {
 
   // 상태 기계 설정을 진행한다.
   override fun configure(
-    config: StateMachineConfigurationConfigurer<DocumentState, DocumentEvent>
-  ) {
+    config: StateMachineConfigurationConfigurer<DocumentState, DocumentEvent>) {
 
     config.withConfiguration()
       .autoStartup(true)
@@ -35,13 +34,12 @@ class DocumentStateConfig : EnumStateMachineConfigurerAdapter<DocumentState, Doc
       .state(DocumentState.UNDER_MEDIATION)
       .state(DocumentState.WAITING_FOR_PUBLIC_DISCLOSURE)
       .state(DocumentState.PUBLIC_DISCLOSURE, SendEmailAction()) // state 별 로직을 설정 가능.
-    // .end() // 최종 상태가 존재하는 경우 이 메소드를 통해 설정할 수 있다.
+      // .end() // 최종 상태가 존재하는 경우 이 메소드를 통해 설정할 수 있다.
   }
 
   // 상태 기계의 'event (이벤트)' 와 'state transition (상태 전이)' 를 매핑한다.
   override fun configure(
-    transitions: StateMachineTransitionConfigurer<DocumentState, DocumentEvent>
-  ) {
+    transitions: StateMachineTransitionConfigurer<DocumentState, DocumentEvent>) {
 
     transitions.withExternal()
       .source(DocumentState.DRAFT).target(DocumentState.UNDER_MEDIATION)


### PR DESCRIPTION
- SQL
  - 코드 컨벤션을 아래와 같이 통일시켜주었습니다.
    - 소문자 : 테이블 명, 칼럼 명 - 대문자 : 테이블 명, 칼럼 명을 제외한 모든 키워드
- Kotlin :
  - configuration 클래스 이름을 변경해주었습니다
    - `DocumentStateConfig` -> `DocumentStateMachineConfig`
  - 불필요한 nullable 관련 기호 및, 유틸리티 기능 사용 코드를 수정해주었습니다.
- Java :
  - 불필요한 공백을 제거해주었습니다.
  - configuration 클래스 이름을 변경해주었습니다.
    - `DocumentStateConfig` -> `DocumentStateMachineConfig`