### PR TITLE
코틀린 프로젝트에서 사용하는 코틀린 버전과, 타겟 JVM 버전을 변경하라

### DIFF
--- a/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/build.gradle
+++ b/simple-statemachine-with-persistence/uising-statemachine-data-jpa/simple-statemachine-kotlin/build.gradle
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id 'org.springframework.boot' version '2.7.12'
     id 'io.spring.dependency-management' version '1.1.3'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.20-Beta2'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.20-Beta2'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.20-RC2'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.20-RC2'
 }
 
 group = 'com.example.statemachine'

--- a/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/build.gradle
+++ b/simple-statemachine-with-persistence/using-statemachine-recipe/simple-statemachine-kotlin/build.gradle
@@ -2,16 +2,16 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id 'org.springframework.boot' version '3.1.4'
     id 'io.spring.dependency-management' version '1.1.3'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.20-Beta2'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.20-Beta2'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.20-RC2'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.20-RC2'
 }
 
 group = 'com.example.statemachine'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 ext {
@@ -50,7 +50,7 @@ dependencies {
 tasks.withType(KotlinCompile) {
     kotlinOptions {
         freeCompilerArgs += '-Xjsr305=strict'
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = JavaVersion.VERSION_21
     }
 }
 

--- a/simple-statemachine/simple-statemachine-kotlin/build.gradle
+++ b/simple-statemachine/simple-statemachine-kotlin/build.gradle
@@ -2,16 +2,16 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id 'org.springframework.boot' version '3.1.4'
     id 'io.spring.dependency-management' version '1.1.3'
-    id 'org.jetbrains.kotlin.jvm' version '1.9.20-Beta2'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.20-Beta2'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.20-RC2'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.20-RC2'
 }
 
 group = 'com.example.statemachine'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 ext {
@@ -47,7 +47,7 @@ dependencies {
 tasks.withType(KotlinCompile) {
     kotlinOptions {
         freeCompilerArgs += '-Xjsr305=strict'
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = JavaVersion.VERSION_21
     }
 }
 


### PR DESCRIPTION
- 코틀린 버전을 변경해주었습니다.
  - 1.9.20-Beta2 -> 1.9.20-RC2
- 코틀린 버전 1.9.20-RC2 에서 JDK 버전 21 에 대한 대응이 원할한 것을 확인하여, 타깃 JVM 버전을 변경해주었습니다.
  - 17 -> 21